### PR TITLE
Create sarif_import.yml

### DIFF
--- a/.github/workflows/sarif_import.yml
+++ b/.github/workflows/sarif_import.yml
@@ -1,0 +1,44 @@
+name: Security Scan + Conviso importation
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  # You can change the Scanner here to any who performs SARIF output
+  scan:
+    name: Security Scan
+    runs-on: ubuntu-20.04
+    container:
+      image: returntocorp/semgrep
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Semgrep scan
+        id: scan
+        run: semgrep --config=auto --sarif -o results.sarif
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: results.sarif
+          path: results.sarif
+  import:
+    name: Conviso Findings Importation
+    needs: scan
+    runs-on: ubuntu-20.04
+    container:
+      image: convisoappsec/flowcli:1.12.0-rc.2
+      env:
+        FLOW_API_KEY: ${{secrets.CONVISO_API_KEY}}
+        FLOW_PROJECT_CODE: ${{secrets.CONVISO_PROJECT_CODE}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Download result from previous scan
+        uses: actions/download-artifact@v3
+        with:
+          name: results.sarif
+      - name: SARIF Importation
+        run: |
+          conviso findings import-sarif --input-file results.sarif


### PR DESCRIPTION
Adds Sarif import functionality from Conviso CLI using a third-party scanner, [Trivy](https://trivy.dev/), importing its result to the Conviso Platform.

Further information on https://docs.convisoappsec.com/cli/findings/

Suggestion by @htrgouvea 